### PR TITLE
Remove reserve query check from every page load.

### DIFF
--- a/plugins/woocommerce/src/StoreApi/Utilities/QuantityLimits.php
+++ b/plugins/woocommerce/src/StoreApi/Utilities/QuantityLimits.php
@@ -210,11 +210,7 @@ final class QuantityLimits {
 		if ( is_null( $product->get_stock_quantity() ) ) {
 			return null;
 		}
-
-		$reserve_stock  = new ReserveStock();
-		$reserved_stock = $reserve_stock->get_reserved_stock( $product, $this->get_draft_order_id() );
-
-		return $product->get_stock_quantity() - $reserved_stock;
+		return $product->get_stock_quantity();
 	}
 
 	/**


### PR DESCRIPTION
This query is causing some issues on the site with heavy checkout activity, we don't need to run it on shop page load. We anyway do it on checkout which prevent issues.